### PR TITLE
active abilities fix and extra life purchase limit

### DIFF
--- a/WaveGameB4Master-master/src/mainGame/HUD.java
+++ b/WaveGameB4Master-master/src/mainGame/HUD.java
@@ -32,6 +32,7 @@ public class HUD {
 	private Color freezeColor = new Color(0, 255, 255, 25);
 	private Color regenColor = new Color(120, 255, 120);
 	private int extraLives = 0;
+	private static int NUM_LIVES_MAX = 1;
 	private double randnumber;
 	private String highScoreString = "";
 	private double costMultipier = 1.25;
@@ -40,6 +41,7 @@ public class HUD {
 	private double activeCost = 3000;
 	private static double ACTIVECOST =3000;
 	private int numFreeze=0;
+	private static int NUM_FREEZE_MAX = 2;
 	private static int NUM_REGEN_VALUE = 0;
 	private int numRegen=0;
 	private int numRegenMax = 10;//max number allowed for regen perk
@@ -56,6 +58,7 @@ public class HUD {
 	private int numArmor=NUM_ARMOR;
 	private static int numArmorMax = 5;
 	private int numClear=0;
+	private static int NUM_CLEAR_MAX = 2;
 	private double regenValue = 0; //total value is restricted by numRegenMax after scalar multiplication
 	private double regenValueScalar = .1;//scalar for regenValue, is multiplied by numRegen
 
@@ -64,9 +67,16 @@ public class HUD {
 	public int getNumClear() {
 		return numClear;
 	}
+	public int getNumClearMax(){
+		return NUM_CLEAR_MAX;
+	}
 
 	public void setNumClear() {
 		this.numClear += 1;
+	}
+
+	public void reduceNumClear(){
+		numClear -= 1;
 	}
 
 	public double getregenValue() {
@@ -120,10 +130,17 @@ public class HUD {
 	public int getNumFreeze() {
 		return numFreeze;
 	}
+	public int getNumFreezeMax(){
+		return NUM_FREEZE_MAX;
+	}
 
 	public void setNumFreeze() {
 		this.numFreeze += 1;
 	}
+	public void reduceNumFreeze(){
+		this.numFreeze -= 1;
+	}
+
 
 	public int getNumRegen() {
 		return numRegen;
@@ -365,13 +382,9 @@ public class HUD {
 		return this.extraLives;
 	}
 
-	/*
-	public void healthIncrease() {
-		//healthValueMax = healthValueMax+healthScalar;
-		//this.healthValue = healthValueMax;
-		healthBarModifier = (250/healthValueMax);
-		healthBarWidth = 4*(int)healthValueMax;
-	}*/
+	public int getNumLivesMax(){
+		return NUM_LIVES_MAX;
+	}
 
 ///////////////////individual power-ups reset section/////////////////////
 	public void resetRegen() {
@@ -387,11 +400,6 @@ public class HUD {
 	}
 	public void resetHealth() {
 
-		/*health = false;
-		healthValueMax = BASE_HEALTH;
-		this.healthValue = healthValueMax;
-		healthBarModifier = 2.5;
-		healthBarWidth = 400;*/
 		health = false;
 		numHealth = NUMHEALTH;
 		healthValueMax = BASE_HEALTH;//additional piece

--- a/WaveGameB4Master-master/src/mainGame/MouseListener.java
+++ b/WaveGameB4Master-master/src/mainGame/MouseListener.java
@@ -27,6 +27,8 @@ public class MouseListener extends MouseAdapter {
 	private Player player;
 	private String upgradeText;
 	private Pause pause;
+	private static int FREEZE_USES = 5;
+	private static int CLEAR_USES = 3;
 	public static boolean isHard;
 
 	public MouseListener(Game game, Handler handler, HUD hud, SpawnHard spawnerH, Spawn1to10 spawner, Spawn10to20 spawner2,
@@ -43,6 +45,8 @@ public class MouseListener extends MouseAdapter {
 		this.pause = pause;
 	}
 
+
+
 	public void mousePressed(MouseEvent e) {
 		int mx = (int) (e.getX() / Game.scaleFactor);
 		int my = (int) (e.getY() / Game.scaleFactor);
@@ -52,7 +56,6 @@ public class MouseListener extends MouseAdapter {
 		if (game.gameState == STATE.GameOver) { //geting out of the game when game is over
 			handler.object.clear();
 			upgrades.resetUpgrades();
-			//hud.health = 100; //original was not private
 			hud.reset();
 			hud.setScore(0);
 			hud.setLevel(1);
@@ -319,27 +322,34 @@ public class MouseListener extends MouseAdapter {
 			//Extra Life
 			if (mouseOver(mx, my, 300, 325, 125, 125)) {
 			if(hud.getScore()>=hud.getCost()){
-				hud.setScore(-(int)hud.getCost());
-				hud.setCost(hud.getCost()*hud.getCostMultipier());
-				hud.setExtraLives(hud.getExtraLives() + 1);
+				if(hud.getExtraLives() != hud.getNumLivesMax()){
+					hud.setScore(-(int)hud.getCost());
+					hud.setCost(hud.getCost()*hud.getCostMultipier());
+					hud.setExtraLives(hud.getExtraLives() + 1);
+				}
 				}
 			}
 			//Freeze Time
 			if (mouseOver(mx, my, 100, 650, 125, 125)) {
 				if(upgrades.getAbility().equals("")){
 				if (hud.getScore() >= hud.getActiveCost()) {
-					hud.setScore(-(int) hud.getActiveCost());
-					hud.setActiveCost(hud.getActiveCost() * 2);
-					upgrades.setAbility("freezeTime");
-					hud.setNumFreeze();
+					if(hud.getNumFreeze() != hud.getNumFreezeMax()){
+						hud.setScore(-(int) hud.getActiveCost());
+						hud.setActiveCost(hud.getActiveCost() * 2);
+						upgrades.setAbility("freezeTime");
+						hud.setNumFreeze();
+					}
 					}
 				}
 				else if(upgrades.getAbility().equals("freezeTime")){
 					if (hud.getScore() >= hud.getActiveCost()) {
-						hud.setScore(-(int) hud.getActiveCost());
-						hud.setActiveCost(hud.getActiveCost() * 2);
-						hud.setAbilityUses(5);
-						hud.setNumFreeze();
+						if(hud.getNumFreeze() != hud.getNumFreezeMax()){
+							hud.setScore(-(int) hud.getActiveCost());
+							hud.setActiveCost(hud.getActiveCost() * 2);
+							hud.setAbilityUses(FREEZE_USES);
+							upgrades.setAbilityFreeze(FREEZE_USES);
+							hud.setNumFreeze();
+						}
 					}
 				}
 			}
@@ -347,18 +357,23 @@ public class MouseListener extends MouseAdapter {
 			if (mouseOver(mx, my, 500, 650, 125, 125)) {
 				if(upgrades.getAbility().equals("")) {
 					if (hud.getScore() >= hud.getActiveCost()) {
-						hud.setScore(-(int) hud.getActiveCost());
-						hud.setActiveCost(hud.getActiveCost() * 2);
-						upgrades.setAbility("clearScreen");
-						hud.setNumClear();
+						if(hud.getNumClear() != hud.getNumClearMax()){
+							hud.setScore(-(int) hud.getActiveCost());
+							hud.setActiveCost(hud.getActiveCost() * 2);
+							upgrades.setAbility("clearScreen");
+							hud.setNumClear();
+						}
 					}
 				}
 				else if(upgrades.getAbility().equals("clearScreen")){
 					if (hud.getScore() >= hud.getActiveCost()) {
-						hud.setScore(-(int) hud.getActiveCost());
-						hud.setActiveCost(hud.getActiveCost() * 2);
-						hud.setAbilityUses(3);
-						hud.setNumClear();
+						if(hud.getNumClear() != hud.getNumClearMax()){
+							hud.setScore(-(int) hud.getActiveCost());
+							hud.setActiveCost(hud.getActiveCost() * 2);
+							hud.setAbilityUses(CLEAR_USES);
+							upgrades.setAbilityClear(CLEAR_USES);
+							hud.setNumClear();
+						}
 					}
 				}
 			}

--- a/WaveGameB4Master-master/src/mainGame/Upgrades.java
+++ b/WaveGameB4Master-master/src/mainGame/Upgrades.java
@@ -18,6 +18,10 @@ public class Upgrades {
 	private Spawn10to20 spawner2;
 	private UpgradeScreen upgradeScreen;
 	private String ability = "";
+	private int useCounterFreeze = 0;
+	private int useCounterClear = 0;
+	private int abilityFreeze = 0;
+	private int abilityClear = 0;
 	private static double SIZE_SCALAR = .1;
 	private static double DAMAGE_RESISTANCE_SCALAR = .05;
 	private static double SPEED_BOOST_SCALAR = 1.5;
@@ -33,13 +37,28 @@ public class Upgrades {
 		this.spawner = spawner;
 		this.spawner2 = spawner2;
 	}
+	public void setAbilityFreeze(int freeze){
+		abilityFreeze = freeze;
+	}
+
+	public void setAbilityClear(int clear){
+		abilityClear = clear;
+	}
 
 	public void clearScreenAbility() {
 		handler.clearEnemies();
 		hud.setAbilityUses(-1);
+		useCounterClear += 1;
 		if (hud.getAbilityUses() == 0) {
+			hud.reduceNumClear();
 			ability = "";
+			hud.setAbility(ability);
 		}
+		else if(useCounterClear == abilityClear){
+			hud.reduceNumClear();
+			useCounterClear = 0;
+		}
+
 	}
 
 	public void decreasePlayerSize() {//changed math to not have reduced outcomes per purchase
@@ -99,9 +118,17 @@ public class Upgrades {
 		Spawn1to10.setSpawn(false);
 		Spawn10to20.setSpawn(false);
 		hud.setAbilityUses(-1);
+		useCounterFreeze += 1;
 		if (hud.getAbilityUses() == 0) {
+			hud.reduceNumFreeze();
 			ability = "";
+			hud.setAbility(ability);
 		}
+		else if(useCounterFreeze  == abilityFreeze){
+			hud.reduceNumFreeze();
+			useCounterFreeze = 0;
+		}
+
 	}
 
 	public void speedBoost() {


### PR DESCRIPTION
… abilities decrement in upgrades screen as they are consumed in their number of uses i.e. screen clear comes with 3 uses, decrements ability purchase amount by 1 after 3 uses in game etc. limit put on extra life, only one can be bought at a time, fixed a bug which prevented purchase of other active abilities when you ran out of uses i.e. 0 uses left